### PR TITLE
Fixed README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 ## Example: Using the Python Client:
 ```python
 from gearsclient import GearsRemoteBuilder as GearsBuilder
+from gearsclient import execute
 import redis
 
 conn = redis.Redis(host='localhost', port=6379)


### PR DESCRIPTION
`execute` was not imported in the example.