### PR TITLE
Version bump from 0.0.1 to 1.0.2. 

### DIFF
--- a/gearsclient/__init__.py
+++ b/gearsclient/__init__.py
@@ -1,1 +1,2 @@
+from ._version import __version__
 from .redisgears_builder import GearsRemoteBuilder, log, gearsConfigGet, execute, atomic, hashtag

--- a/gearsclient/_version.py
+++ b/gearsclient/_version.py
@@ -1,0 +1,3 @@
+# This attribute is the only one place that the version number is written down,
+# so there is only one place to change it when the version number changes.
+__version__ = "1.0.2"

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,23 @@
 from setuptools import setup, find_packages
 import io
 
+def read_version(version_file):
+    """
+    Given the input version_file, this function extracts the
+    version info from the __version__ attribute.
+    """
+    version_str = None
+    import re
+    verstrline = open(version_file, "rt").read()
+    VSRE = r"^__version__ = ['\"]([^'\"]*)['\"]"
+    mo = re.search(VSRE, verstrline, re.M)
+    if mo:
+        version_str = mo.group(1)
+    else:
+        raise RuntimeError("Unable to find version string in %s." % (version_file,))
+    return version_str
+
+
 def read_all(f):
     with io.open(f, encoding="utf-8") as I:
         return I.read()
@@ -9,7 +26,7 @@ requirements = list(map(str.strip, open("requirements.txt").readlines()))
 
 setup(
     name='gearsclient',
-    version='0.1',
+    version=read_version("gearsclient/_version.py"),
     description='RedisGears Python Client',
     long_description=read_all("README.md"),
     long_description_content_type='text/markdown',

--- a/test.py
+++ b/test.py
@@ -3,6 +3,10 @@ from gearsclient import log, hashtag, execute, atomic
 
 counter = 0
 
+def testVersionRuntime(self):
+    import gearsclient as gears_pkg
+    self.assertNotEqual("",gears_pkg.__version__)
+
 def getGB(env, reader='KeysReader'):
     return GRB(reader, r=env.getConnection(), addClientToRequirements=False) 
 


### PR DESCRIPTION
Fixes #14 
Apart from it, it also exposes the package version at runtime.
Here's a discussion on how to standardize this info: https://stackoverflow.com/questions/458550/standard-way-to-embed-version-into-python-package