### PR TITLE
Removing LGTM

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![CircleCI](https://circleci.com/gh/RedisGears/redisgears-py/tree/master.svg?style=svg)](https://circleci.com/gh/RedisGears/redisgears-py/tree/master)
 [![GitHub issues](https://img.shields.io/github/release/RedisGears/redisgears-py.svg)](https://github.com/RedisGears/redisgears-py/releases/latest)
 [![Codecov](https://codecov.io/gh/RedisGears/redisgears-py/branch/master/graph/badge.svg)](https://codecov.io/gh/RedisGears/redisgears-py)
-[![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/RedisGears/redisgears-py.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/RedisGears/redisgears-py/context:python)
 [![Known Vulnerabilities](https://snyk.io/test/github/RedisGears/redisgears-py/badge.svg?targetFile=pyproject.toml)](https://snyk.io/test/github/RedisGears/redisgears-pytargetFile=pyproject.toml)
 
 # redisgears-py


### PR DESCRIPTION
The LGTM service is being shut off in two weeks. This pull request aims to remove all references to LGTM. Perhaps LGTM usage should be replaced with codeql, or a repository preferred tool, but IMHO that's the point of a different pull request.